### PR TITLE
Add mission name validation to audits

### DIFF
--- a/cogs/missions.py
+++ b/cogs/missions.py
@@ -344,7 +344,8 @@ class Missions(commands.Cog, name = "Missions"):
 
 		# Start doing some validation on the contents of the mission file
 		try:
-			missionPBO = pboutil.PBOFile.from_bytes(missionfile.read())
+			missionFileBytes = await missionfile.read()
+			missionPBO = pboutil.PBOFile.from_bytes(missionFileBytes)
 		except:
 			await interaction.response.send_message("I encountered an error verifying the validity of your mission file."
 				"\nPlease ensure that you are submitting a mission in PBO format, exported from the Arma 3 editor.")
@@ -379,21 +380,25 @@ class Missions(commands.Cog, name = "Missions"):
 		# Correct naming structure: COOP 52+2 - Daybreak v1.8
 		# Start by splitting the name into two parts
 		briefingArr1 = briefingName.split("-",1)
-		if len(briefingArr1) < 2:
-			await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
-			"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines.")
-			return
+		# Remove this temporarily for now. To be replaced with regEx at some point in the future.
+		#if len(briefingArr1) < 2:
+		#	await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
+		#	"\nYour `briefingName` entry may be missing a `-` between the player count and mission name."
+		#	"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.")
+		#	return
 		# This will give us an list that looks like this: "COOP 52+2", "Daybreak v1.8"
 		# Check to see if the first part is valid
 		briefingArr2 = briefingArr1[0].split(" ",1)
 		if len(briefingArr2) < 2:
 			await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
-			"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines.")
+				"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
+				ephemeral = True)
 			return
 		# We should now be able to verify that the mission type in the briefingname is valid
 		if briefingArr2[0].lower() not in VALID_GAMETYPES:
-			await interaction.response.send_message(f"The gametype `{briefingArr2[0]}` found in your `description.ext` file is not a valid gametype."
-				"\nPlease ensure that your mission is named according to the mission naming guidelines.")
+			await interaction.response.send_message(f"The gametype `{briefingArr2[0]}` found in the `briefingName` entry in your `description.ext` file is not a valid gametype."
+				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
+				ephemeral = True)
 			return
 
 

--- a/cogs/missions.py
+++ b/cogs/missions.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import gspread_asyncio
 from google.oauth2.service_account import Credentials
 import pboutil
-import armaclass
+import re
 
 import blueonblue
 
@@ -361,9 +361,19 @@ class Missions(commands.Cog, name = "Missions"):
 		except:
 			await interaction.response.send_message("I encountered an issue reading your mission's `description.ext` file."
 				"\nPlease ensure that your mission contains a description.ext file, with a filename in all-lowercase.")
+			return
 
-		# Regex: (?<=\sbriefingName\s=\s[\"\'])[^\"\']*
-		# re.search("re", descriptionFile, re.I)
+		# Use a regex search to find the briefingName in the description.ext file
+		briefingMatch = re.search("(?<=^briefingName\s=\s[\"\'])[^\"\']*", descriptionFile, re.I | re.M)
+
+		if briefingMatch is None:
+			await interaction.response.send_message("I could not determine the `briefingName` of your mission from its `description.ext` file."
+				"\nPlease ensure that your mission has a `briefingName` defined.")
+			return
+
+		briefingName = briefingMatch.group()
+
+		# Now that we have the briefingName, we need to validate it.
 
 
 		# Mission has passed validation checks

--- a/cogs/missions.py
+++ b/cogs/missions.py
@@ -376,38 +376,13 @@ class Missions(commands.Cog, name = "Missions"):
 
 		briefingName = briefingMatch.group()
 
-		# # Now that we have the briefingName, we need to validate it.
-		# # Correct naming structure: COOP 52+2 - Daybreak v1.8
-		# # Start by splitting the name into two parts
-		# briefingArr1 = briefingName.split("-",1)
-		# # Remove this temporarily for now. To be replaced with regEx at some point in the future.
-		# #if len(briefingArr1) < 2:
-		# #	await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
-		# #	"\nYour `briefingName` entry may be missing a `-` between the player count and mission name."
-		# #	"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.")
-		# #	return
-		# # This will give us an list that looks like this: "COOP 52+2", "Daybreak v1.8"
-		# # Check to see if the first part is valid
-		# briefingArr2 = briefingArr1[0].split(" ",1)
-		# if len(briefingArr2) < 2:
-		# 	await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
-		# 		"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
-		# 		ephemeral = True)
-		# 	return
-		# # We should now be able to verify that the mission type in the briefingname is valid
-		# if briefingArr2[0].lower() not in VALID_GAMETYPES:
-		# 	await interaction.response.send_message(f"The gametype `{briefingArr2[0]}` found in the `briefingName` entry in your `description.ext` file is not a valid gametype."
-		# 		"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
-		# 		ephemeral = True)
-		# 	return
-
 		# Now that we have the briefingName, we need to validate it.
 		# Correct naming structure: COOP 52+2 - Daybreak v1.8
 		# Start by setting up a regex match for the briefing name
 		briefingRe = re.compile(
 			r"^(?P<modnight>modnight )?(?:(?P<gametype>[a-zA-Z]+) )?" \
 			r"(?P<playercount>\d+)?(?:\+(?P<extracount>\d*))? ?(?:\- *)?(?P<name>.*?)" \
-			r"(?: v?(?P<version>\d+(?:\.\d+)?))?$",
+			r"(?: v?(?P<version>\d+(?:\.\d+)*?))?$",
 			re.MULTILINE + re.IGNORECASE
 		)
 
@@ -431,42 +406,42 @@ class Missions(commands.Cog, name = "Missions"):
 		# briefingName exists, check to make sure that we have detected a gametype, playercont, name, and version
 		if (modpreset is not None) and (bModnight is None):
 			await interaction.response.send_message("Modnight missions must have their `briefingName` entries in `description.ext` prefixed with \"MODNIGHT\"."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return
 
 		if bGametype is None:
 			await interaction.response.send_message("Could not determine your mission's gametype from the `briefingName` entry in your `description.ext` file."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return
 
 		if bPlayerCount is None:
 			await interaction.response.send_message("Could not determine your mission's player count from the `briefingName` entry in your `description.ext` file."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return
 
 		if bName is None:
 			await interaction.response.send_message("Could not determine your mission's name from the `briefingName` entry in your `description.ext` file."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return
 
 		if bVersion is None:
 			await interaction.response.send_message("Could not determine your mission's version from the `briefingName` entry in your `description.ext` file."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return
 
 		if bGametype.casefold() not in VALID_GAMETYPES:
 			await interaction.response.send_message(f"The gametype `{bGametype}` found in the `briefingName` entry in your `description.ext` file is not a valid gametype."
-				f"\nDetected `briefingName` was: `{briefingNameMatch}`"
+				f"\nDetected `briefingName` was: `{briefingNameMatch.group()}`"
 				"\nPlease ensure that your mission is named according to the mission naming guidelines. Example: `COOP 52+1 - Daybreak v1.8`.",
 				ephemeral = True)
 			return

--- a/cogs/missions.py
+++ b/cogs/missions.py
@@ -19,6 +19,8 @@ MISSION_EMBED_COLOUR = 0x2E86C1
 
 ISO_8601_FORMAT = "%Y-%m-%d"
 
+VALID_GAMETYPES = ["coop", "tvt", "cotvt", "rptvt", "zeus", "zgm", "rpg"]
+
 def _decode_file_name(filename: str) -> dict:
 	"""Decodes the file name for a mission to collect information about it.
 	Returns a dict of parameters if successful, otherwise raises an error."""
@@ -47,7 +49,7 @@ def _decode_file_name(filename: str) -> dict:
 
 	# Check the mission type
 	gameType = nameList[0].casefold()
-	if not (gameType in ["coop", "tvt", "cotvt", "rptvt", "zeus", "zgm", "rpg"]):
+	if not (gameType in VALID_GAMETYPES):
 		raise Exception(f"`{gameType}` is not a valid mission type!")
 
 	# Grab the player count
@@ -374,6 +376,26 @@ class Missions(commands.Cog, name = "Missions"):
 		briefingName = briefingMatch.group()
 
 		# Now that we have the briefingName, we need to validate it.
+		# Correct naming structure: COOP 52+2 - Daybreak v1.8
+		# Start by splitting the name into two parts
+		briefingArr1 = briefingName.split("-",1)
+		if len(briefingArr1) < 2:
+			await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
+			"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines.")
+			return
+		# This will give us an list that looks like this: "COOP 52+2", "Daybreak v1.8"
+		# Check to see if the first part is valid
+		briefingArr2 = briefingArr1[0].split(" ",1)
+		if len(briefingArr2) < 2:
+			await interaction.response.send_message("Error parsing `briefingName` from `description.ext` file."
+			"\nPlease ensure that your `briefingName` entry follows the mission naming guidelines.")
+			return
+		# We should now be able to verify that the mission type in the briefingname is valid
+		if briefingArr2[0].lower() not in VALID_GAMETYPES:
+			await interaction.response.send_message(f"The gametype `{briefingArr2[0]}` found in your `description.ext` file is not a valid gametype."
+				"\nPlease ensure that your mission is named according to the mission naming guidelines.")
+			return
+
 
 
 		# Mission has passed validation checks

--- a/cogs/missions.py
+++ b/cogs/missions.py
@@ -459,7 +459,7 @@ class Missions(commands.Cog, name = "Missions"):
 		await auditModal.wait()
 
 		# If we did not get a response, cancel the remainder of the command
-		if auditModal.audit_notes.value is None:
+		if (auditModal.audit_notes.value is None) or (auditModal.audit_notes.value == ""):
 			return
 
 		# Start creating our audit message

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-git+https://github.com/Rapptz/discord.py
+discord.py>=2.0.1
 git+https://github.com/Rapptz/asqlite
 gspread_asyncio==1.5.3
 aiohttp>=3.7.4
 parsedatetime>=2.6
+tomlkit>=0.11.4
+pboutil>=0.1.1
+armaclass>=0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Rapptz/discord.py
+discord.py>=2.1.0
 git+https://github.com/Rapptz/asqlite
 gspread_asyncio==1.5.3
 aiohttp>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 discord.py>=2.1.0
 git+https://github.com/Rapptz/asqlite
-gspread_asyncio==1.5.3
-aiohttp>=3.7.4
+gspread_asyncio>=1.7.1
+aiohttp>=3.8.1
 parsedatetime>=2.6
-tomlkit>=0.11.4
+tomlkit>=0.11.6
 pboutil>=0.1.1
 armaclass>=0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py>=2.0.1
+git+https://github.com/Rapptz/discord.py
 git+https://github.com/Rapptz/asqlite
 gspread_asyncio==1.5.3
 aiohttp>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ git+https://github.com/Rapptz/asqlite
 gspread_asyncio>=1.7.1
 aiohttp>=3.8.1
 parsedatetime>=2.6
-tomlkit>=0.11.6
 pboutil>=0.1.1
-armaclass>=0.2.2


### PR DESCRIPTION
Adds automated mission name validation to the audit command.
The bot will now automatically reject missions that do not adhere to the mission naming guidelines.